### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 from app.models import db, Product, User, Order
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from pi_network import PiNetwork
+import logging
 
 main = Blueprint('main', __name__)
 
@@ -57,4 +58,5 @@ def process_payment():
         payment = pi.process_payment(tx_id)
         return jsonify({"status": "success", "payment": payment}), 200
     except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 400
+        app.logger.error(f"Error processing payment: {str(e)}")
+        return jsonify({"status": "error", "message": "An internal error has occurred."}), 400


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/Palace-of-Goods/security/code-scanning/3](https://github.com/erikg713/Palace-of-Goods/security/code-scanning/3)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Modify the exception handling block to log the detailed exception message.
3. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
