### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/backend/app/controllers/payment_controller.py
+++ b/backend/app/controllers/payment_controller.py
@@ -44,4 +44,5 @@ def initiate_payment():
         else:
             return jsonify({'message': 'Failed to initiate payment', 'error': response_data}), response.status_code
     except Exception as e:
-        return jsonify({'message': 'An error occurred while initiating payment', 'error': str(e)}), 500
+        app.logger.error('An error occurred while initiating payment: %s', str(e))
+        return jsonify({'message': 'An error occurred while initiating payment'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/Palace-of-Goods/security/code-scanning/2](https://github.com/erikg713/Palace-of-Goods/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach maintains the ability to debug issues while protecting sensitive information from being exposed.

1. Modify the exception handling block to log the detailed error message.
2. Return a generic error message to the user without including the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
