### PR TITLE
Potential fix for code scanning alert no. 11: Database query built from user-controlled sources

### DIFF
--- a/server/src/controllers/ProductController.ts
+++ b/server/src/controllers/ProductController.ts
@@ -41,7 +41,7 @@ export const getProducts = async (req: Request, res: Response) => {
     const filter: any = {};
 
     if (search) filter.name = { $regex: search, $options: "i" };
-    if (category) filter.category = category;
+    if (category) filter.category = { $eq: category };
 
     const products = await Product.find(filter)
       .skip((Number(page) - 1) * Number(limit))


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/palace-of-goods/security/code-scanning/11](https://github.com/erikg713/palace-of-goods/security/code-scanning/11)

To fix the problem, we need to ensure that the `category` parameter is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the user input is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
