### PR TITLE
Potential fix for code scanning alert no. 22: Missing rate limiting

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,19 +12,15 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^6.14.1",
     "react": "^19.1.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.1.5",
-    "redux": "^4.2.1",
-    "react-redux": "^9.2.0",
     "redux": "^5.0.1",
     "react-redux": "^8.1.0",
     "redux-thunk": "^2.4.2",
     "styled-components": "^6.0.3",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "eslint": "^8.40.0",
@@ -64,6 +60,9 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"]
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   }
 }

--- a/client/src/api/verifyPayment.ts
+++ b/client/src/api/verifyPayment.ts
@@ -1,10 +1,21 @@
 import express from "express";
+import rateLimit from "express-rate-limit";
 import { verifyPiTransaction } from "./piPayments";
 
 const app = express();
 app.use(express.json());
 
-app.post("/api/verify-payment", async (req, res) => {
+// Set up rate limiter: max 100 requests per 15 minutes per IP for this endpoint
+const verifyPaymentLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: {
+    success: false,
+    message: "Too many requests, please try again later."
+  },
+});
+
+app.post("/api/verify-payment", verifyPaymentLimiter, async (req, res) => {
   const { paymentId } = req.body;
 
   if (!paymentId) {


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/palace-of-goods/security/code-scanning/22](https://github.com/erikg713/palace-of-goods/security/code-scanning/22)

To fix this problem, we should add a rate limiting middleware to the Express app. The best way is to use the popular `express-rate-limit` npm package. We import it, create a limiter with reasonable defaults (such as no more than 100 requests per 15 minutes per IP), and apply it to the `/api/verify-payment` POST endpoint with `app.use` or as route-specific middleware before the handler function.

**Specifically:**
- Add an import for `express-rate-limit`.
- Instantiate a rate limiter, for example with a window of 15 minutes and a maximum of 100 requests per IP.
- Apply the limiter to the `/api/verify-payment` POST route. It's best to apply it as middleware directly to that route, so other endpoints are unaffected.
- No changes to the rest of the application's logic or endpoint implementation are necessary.

Required edits:
- Add `express-rate-limit` import and limiter definition near the top.
- Apply limiter as middleware in the `app.post("/api/verify-payment", ...)` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
