### PR TITLE
Potential fix for code scanning alert no. 24: Information exposure through a stack trace

### DIFF
--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -109,7 +109,8 @@ router.post("/register", async (req, res) => {
     await newUser.save();
     res.status(201).json("User registered successfully!");
   } catch (err) {
-    res.status(500).json(err);
+    console.error("❌ Register error:", err);
+    res.status(500).json({ error: "Internal server error" });
   }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/palace-of-goods/security/code-scanning/24](https://github.com/erikg713/palace-of-goods/security/code-scanning/24)

**How to fix in general:**  
Ensure that sensitive error information—such as stack traces—is never sent to the client. Instead, log detailed errors server-side and send a generic error message to the user.

**Single best way to fix in this context:**  
Replace `res.status(500).json(err);` with logging the error (e.g., `console.error(err);`) and responding with `res.status(500).json({ error: "Internal server error" });` or a similarly non-specific message. This preserves the current code's functionality (the client gets a 500 error and a message) without exposing internal details. Make this change in the catch block for the `/register` handler.

**Files/lines to change:**  
Edit `server/src/routes/authRoutes.ts`, specifically lines 111-113 (the catch block for the `/register` handler).

**What's needed:**  
- Add server-side logging (console.error(err)), if not already present.
- Replace the response to the client with a generic message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
